### PR TITLE
Add rsync support.  Add precise pressure and pressure trend fields.

### DIFF
--- a/bin/user/rtgd.py
+++ b/bin/user/rtgd.py
@@ -1887,8 +1887,6 @@ class RealtimeGaugeDataThread(threading.Thread):
         press = convert(press_vt, self.pres_group).value
         press = press if press is not None else 0.0
         data['press'] = self.pres_format % press
-        # Also include pressure with extra precision.
-        data['pressPRECISE'] = "%.4f" % press
         # pressTL - today's low barometer
         # pressTH - today's high barometer
         # TpressTL - time of today's low barometer (hh:mm)
@@ -1959,8 +1957,6 @@ class RealtimeGaugeDataThread(threading.Thread):
                                   self.db_manager, ts - 3600, 300)
         presstrendval = _p_trend_val if _p_trend_val is not None else 0.0
         data['presstrendval'] = self.pres_format % presstrendval
-        # Also include a pressure trend with extra precision.
-        data['presstrendvalPRECISE'] = "%.6f" % presstrendval
         # rfall - rain today
         rain_day = self.day_stats['rain'].sum + self.buffer.rainsum
         rain_t_vt = ValueTuple(rain_day, self.p_rain_type, self.p_rain_group)


### PR DESCRIPTION
Hi Gary,

I’ve been running a modified copy of your rtgd.py file for about nine months or so.  Besides using the gauges, I have a modified Seasons skin that also updates every two seconds via the gauge-data.txt file.  You can see it in action at www.paloaltoweather.com.  That production version is WeeWX 3.9.2 (modified).  That website is on a Google GCE instance with gauge-data.txt being rsync’d to it every two seconds.

I got a bunch of changes in the WeeWX development branch for 4.x.  Those changes included a change to the rsync utility so that it would work with a single file.  Now that that change is imminent (with the upcoming 4.x release), I’m hoping to get the rsync ability included in rtgd.py.

The change allows one to specify an rsync server.  Furthermore, with the default values, the rsyncs have been very good at keeping up.  For example, as I write this, it’s nearly the end of the day, and logwatch reports the following:

   rsync: files uploaded                                    26096
   rsync: gauge-data: connection timeouts             6

That is, uploading gauge-data.txt every two seconds (the files uploaded also includes the skins sync), the connection only timed out 6 times and there were no write timeouts.  It is set to discard any data older than 4 seconds, but there were none discarded today.

In addition to the rsycn capability, this change includes two new fields in gauge-data.txt.  These two fields are more precise (more decimals) for pressure and pressure trend.  They are used to update the seasons page.

Thank you for considering this change.

Cheers,
John